### PR TITLE
Fixing memory freeing when calling the following routes: Flush, Delete, Overwrite.

### DIFF
--- a/black_marlin.cpp
+++ b/black_marlin.cpp
@@ -32,8 +32,8 @@ void BlackMarlin::Overwrite(std::string p_key, std::string* p_value) {
     auto it = this->m_dict.find(p_key);
 
     if (it != this->m_dict.end()) {
-        delete it->second;
-        it->second = p_value; // TESTING: is this going to work?
+        delete this->m_dict[p_key];
+        this->m_dict[p_key] = p_value;
     }
 }
 
@@ -42,7 +42,7 @@ void BlackMarlin::Delete(const std::string& p_key) {
 
     if (it == this->m_dict.end()) return;
 
-    delete it->second;
+    delete this->m_dict[p_key];
     
 	this->m_dict.erase(p_key);
 }
@@ -66,11 +66,15 @@ void BlackMarlin::Flush() {
 }
 
 void BlackMarlin::ClearDict() {
-    // cleaning up pointers in buckets.
     for (auto it = this->m_dict.begin(); it != this->m_dict.end(); ++it) {
-        delete it->second;
+        delete this->m_dict[it->first];
+        /*
+         * At this point, "this->m_dict[it->first]" has to point to NULL so that it won't throw a heap corruption error. 
+         * This happens because the iterator might call its value or check for a value in the key. This ends up as an invalid read.
+         * Since the read checks for NULL first, the pointers must be set to NULL before any further operation, indicating that a pointer is not pointing to a valid memory region anymore.
+        */
+        this->m_dict[it->first] = NULL;
     }
 
-    // cleaning up the buckets if there are any.
-    this->m_dict.erase(this->m_dict.begin(), this->m_dict.end());
+    this->m_dict.clear();
 }

--- a/http_request_handler.cpp
+++ b/http_request_handler.cpp
@@ -1,3 +1,4 @@
+#include <string>
 #include "http_request_handler.hpp"
 #include "httplib.h"
 #include "black_marlin.hpp"
@@ -32,9 +33,10 @@ void HttpRequestHandler::HandlePost(BlackMarlin& p_black_marlin, const httplib::
 		return;
 	}
 
-	std::string* req_body_ptr = new std::string(p_req.body);
-	p_black_marlin.Set(key, req_body_ptr);
-	p_res.status = (int)StatusCode::kCreated;
+    std::string* req_body_ptr = new std::string(p_req.body);
+
+    p_black_marlin.Set(key, req_body_ptr);
+    p_res.status = (int)StatusCode::kCreated;
 }
 
 void HttpRequestHandler::HandlePutAndPatch(BlackMarlin& p_black_marlin, const httplib::Request& p_req, httplib::Response& p_res) {
@@ -44,15 +46,14 @@ void HttpRequestHandler::HandlePutAndPatch(BlackMarlin& p_black_marlin, const ht
 	}
 
 	const auto& key = p_req.get_param_value("key");
-	auto* body = new std::string(p_req.body);
 
 	if (!p_black_marlin.Exists(key)) {
 		p_res.status = (int)StatusCode::kBadRequest;
 		return;
 	}
 
-	p_black_marlin.Overwrite(key, body);
-	p_res.set_content("", this->m_content_type);
+    std::string* req_body_ptr = new std::string(p_req.body);
+    p_black_marlin.Overwrite(key, req_body_ptr);
 }
 
 void HttpRequestHandler::HandleDelete(BlackMarlin& p_black_marlin, const httplib::Request& p_req, httplib::Response& p_res) {


### PR DESCRIPTION
Fixing flush, delete and overwrite commands throwing invalid read and heap corruption errors and optimizing overwrite route.