### PR TITLE
Fixing Flush command unit test.

### DIFF
--- a/unittests/black_marlin_tests.cpp
+++ b/unittests/black_marlin_tests.cpp
@@ -2,11 +2,11 @@
 #include "catch2.hpp"
 #include "../black_marlin.hpp"
 
-auto black_marlin = BlackMarlin();
+BlackMarlin black_marlin = BlackMarlin();
 
 TEST_CASE("Black Marlin Get and Set Tests", "[Get and Set]")
 {
-	std::cout << "Running Get and Set" << std::endl;
+	std::cout << "Running Get and Set - Set should create a key-value pair in the map and get should return the value associated to the key." << std::endl;
 
 	std::string sample_key = "get and set test";
 
@@ -19,7 +19,7 @@ TEST_CASE("Black Marlin Get and Set Tests", "[Get and Set]")
 
 TEST_CASE("Overwrite tests", "[Overwrite]")
 {
-	std::cout << "Running Overwrite" << std::endl;
+	std::cout << "Running Overwrite - Should overwrite the value associated to the key." << std::endl;
 
 	std::string sample_key = "get and set test";
 	std::string val = "get and set test two";
@@ -32,7 +32,7 @@ TEST_CASE("Overwrite tests", "[Overwrite]")
 
 TEST_CASE("Exists Tests", "[Exists]")
 {
-	std::cout << "Running Exists" << std::endl;
+	std::cout << "Running Exists - Should return true." << std::endl;
 
     std::string key = "get and set test";
 	REQUIRE(black_marlin.Exists(key));
@@ -40,7 +40,7 @@ TEST_CASE("Exists Tests", "[Exists]")
 
 TEST_CASE("Delete Tests", "[Delete]")
 {
-	std::cout << "Running Delete" << std::endl;
+	std::cout << "Running Delete - Delete should remove the key from the std::unordered_map and clear the std::string*." << std::endl;
 
     std::string key = "get and set test";
     black_marlin.Delete(key);
@@ -50,13 +50,18 @@ TEST_CASE("Delete Tests", "[Delete]")
 
 TEST_CASE("Count Test", "[Count]")
 {
-	std::cout << "Running Count" << std::endl;
-	REQUIRE(black_marlin.Count() == 0);
+	std::cout << "Running Count - Should return 1 after inserting a key." << std::endl;
+
+    std::string sample_key = "get and set test";
+
+	black_marlin.Set(sample_key, &sample_key);
+
+	REQUIRE(black_marlin.Count() == 1);
 }
 
 TEST_CASE("Flush Test", "[Flush]")
 {
-	std::cout << "Running Flush" << std::endl;
+	std::cout << "Running Flush - Should run without heap corruption and Count should return 0." << std::endl;
 
     black_marlin.Flush();
     REQUIRE(black_marlin.Count() == 0);

--- a/unittests/black_marlin_tests.cpp
+++ b/unittests/black_marlin_tests.cpp
@@ -34,7 +34,7 @@ TEST_CASE("Exists Tests", "[Exists]")
 {
 	std::cout << "Running Exists - Should return true." << std::endl;
 
-    std::string key = "get and set test";
+	std::string key = "get and set test";
 	REQUIRE(black_marlin.Exists(key));
 }
 
@@ -42,17 +42,17 @@ TEST_CASE("Delete Tests", "[Delete]")
 {
 	std::cout << "Running Delete - Delete should remove the key from the std::unordered_map and clear the std::string*." << std::endl;
 
-    std::string key = "get and set test";
-    black_marlin.Delete(key);
+	std::string key = "get and set test";
+	black_marlin.Delete(key);
 
-    REQUIRE(black_marlin.Count() == 0);
+	REQUIRE(black_marlin.Count() == 0);
 }
 
 TEST_CASE("Count Test", "[Count]")
 {
 	std::cout << "Running Count - Should return 1 after inserting a key." << std::endl;
 
-    std::string sample_key = "get and set test";
+	std::string sample_key = "get and set test";
 
 	black_marlin.Set(sample_key, &sample_key);
 
@@ -63,6 +63,6 @@ TEST_CASE("Flush Test", "[Flush]")
 {
 	std::cout << "Running Flush - Should run without heap corruption and Count should return 0." << std::endl;
 
-    black_marlin.Flush();
-    REQUIRE(black_marlin.Count() == 0);
+	black_marlin.Flush();
+	REQUIRE(black_marlin.Count() == 0);
 }


### PR DESCRIPTION
The tests have been changed so that heap corruption and/or invalid read errors can be caught early. 

As an example: in the past version of Black Marlin, the Flush command was not being tested, since the unit test for Flush had the map size in 0, no iteration was running. This means that nothing tried to free memory at that point, allowing the last bug to go unnoticed until we ran some integration tests with a bunch of sets and ran Flush right after.

This has been fixed in this branch, running the flush, delete and overwrite commands with at least one key. For more complex workflow of "gets and sets", the integration tests got it covered.