### PR TITLE
New feature: Keys with expiration time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,6 @@ cmake_minimum_required (VERSION 3.8)
 project ("black_marlin")
 
 # Add source to this project's executable.
-add_executable (black_marlin "main.cpp" "black_marlin.cpp" "black_marlin.hpp" "httplib.h" "status_code.hpp" "http_request_handler.cpp" "http_request_handler.hpp" "util.cpp")
+add_executable (black_marlin "main.cpp" "black_marlin.cpp" "black_marlin.hpp" "httplib.h" "status_code.hpp" "http_request_handler.cpp" "http_request_handler.hpp" "util.cpp" "util.hpp")
 
 enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,6 @@ cmake_minimum_required (VERSION 3.8)
 project ("black_marlin")
 
 # Add source to this project's executable.
-add_executable (black_marlin "main.cpp" "black_marlin.cpp" "black_marlin.hpp" "httplib.h" "status_code.hpp" "http_request_handler.cpp" "http_request_handler.hpp")
+add_executable (black_marlin "main.cpp" "black_marlin.cpp" "black_marlin.hpp" "httplib.h" "status_code.hpp" "http_request_handler.cpp" "http_request_handler.hpp" "util.cpp")
 
 enable_testing()

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ This also allows servers in an architecture that uses Load Balancing to share ke
 Currently, the application runs on port **7000**. You can access it by making a GET request to http://127.0.0.1:7000/count with your program running, for example.
 The only thing you have to do to integrate with your application is make HTTP requests and handle the responses.
 
+# TODO:
+- Explain how to use the POST route with the "s" query parameter;
+- The "s" query parameter cannot be 0 (zero) or it will return a `400 - Bad Request`. If you want a key that cannot expire unless manually deleted, call `POST` without "s";
+- An expiring key can be deleted like any other using `Delete` or `Flush`;
+- Edit the "how to compile" section to add that the compiler must support `<thread>` since the `cpphttplib` and the main `black_marlin` library use it.
+
 ### For each route and method:
 **Any failed operation will return an HTTP Status Code of `500 - Internal Server Error`**.
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Currently, the application runs on port **7000**. You can access it by making a 
 The only thing you have to do to integrate with your application is make HTTP requests and handle the responses.
 
 # TODO:
-- Explain how to use the POST route with the "s" query parameter;
-- The "s" query parameter cannot be 0 (zero) or it will return a `400 - Bad Request`. If you want a key that cannot expire unless manually deleted, call `POST` without "s";
+- Explain how to use the POST route with the "expiresin" query parameter, e.g. http://127.0.0.1:7000/?key=key&expiresin=900;
+- The "expiresin" query parameter cannot be 0 (zero) or it will return a `400 - Bad Request`. If you want a key that cannot expire unless manually deleted, call `POST` without "s";
 - An expiring key can be deleted like any other using `Delete` or `Flush`;
 - Edit the "how to compile" section to add that the compiler must support `<thread>` since the `cpphttplib` and the main `black_marlin` library use it.
 

--- a/README.md
+++ b/README.md
@@ -20,12 +20,6 @@ This also allows servers in an architecture that uses Load Balancing to share ke
 Currently, the application runs on port **7000**. You can access it by making a GET request to http://127.0.0.1:7000/count with your program running, for example.
 The only thing you have to do to integrate with your application is make HTTP requests and handle the responses.
 
-# TODO:
-- Explain how to use the POST route with the "expiresin" query parameter, e.g. http://127.0.0.1:7000/?key=key&expiresin=900;
-- The "expiresin" query parameter cannot be 0 (zero) or it will return a `400 - Bad Request`. If you want a key that cannot expire unless manually deleted, call `POST` without "s";
-- An expiring key can be deleted like any other using `Delete` or `Flush`;
-- Edit the "how to compile" section to add that the compiler must support `<thread>` since the `cpphttplib` and the main `black_marlin` library use it.
-
 ### For each route and method:
 **Any failed operation will return an HTTP Status Code of `500 - Internal Server Error`**.
 
@@ -35,7 +29,16 @@ The only thing you have to do to integrate with your application is make HTTP re
 	- Returns: `400 - Bad Request` if no key is sent, `200 - OK` if a key is found and `204 - No Content` if a key is provided but wasn't found.
 
 - `POST` accepts a `key` query parameter (http://127.0.0.1:7000/?key=) and a **body**. The body can be sent in any format.
-	- Returns: `400 - Bad Request` if no key or body was sent in the request and `201 - Created` if the key-value pair was created successfully.
+	- It accepts another query parameter called `expiresin`. This parameter should be an integer representing an amount of seconds: http://127.0.0.1:7000/?key=key&expiresin=900.
+	- **The `expiresin` parameter is optional**, meaning that if you want a key that does not expire unless manually deleted, all you have to do is omit it.
+	- Even if a key has been set to expire, **it can be deleted by calling the default route's `DELETE` method (or `/flush`) or have its value overwritten by the default route's `PUT` or `PATCH`**.
+	- An already existing key cannot be set to expire.
+	- The `expiresin` parameter must be a value bigger than 0 (zero) and less than or equal to `USHRT_MAX` (65535) and cannot be an invalid string such as `"abcd"`, otherwise a `400 - Bad Request` will be returned.
+	- In summary, returns `400 - Bad Request` if:
+		- No `key` parameter was sent;
+		- No body was sent; or
+		- The `expiresin` parameter was sent with an invalid value.
+	- Returns `201 - Created` if the key-value pair was created successfully.
 
 - `PUT and PATCH`: accepts a `key` query parameter (http://127.0.0.1:7000/?key=) and a **body**. The body can be sent in any format.
 	- Returns: `400 - Bad Request` if no key or body was sent in the request and `200 - OK` if the key-value pair was updated successfully.
@@ -58,9 +61,7 @@ The only thing you have to do to integrate with your application is make HTTP re
 
 
 ## Current roadmap:
-- Configurable headers and port through a file in the same directory as the main program;
-- Possible compression of response payload.
-
+- Logging to file. Any exception is currently being written to `STDOUT`;
 
 ## Sidenotes:
 - Currently, this application is not intended to have any sort of security implementation, so it should run inside your organization/project's infraestructure. This decision was made to avoid any kind of overhead.
@@ -71,9 +72,12 @@ The only thing you have to do to integrate with your application is make HTTP re
 Feel free to open issues and fork as you feel like it. I'll be happy to help in any case.
 
 ### How to compile:
-To compile the program on Windows, use Visual Studio (2015, 2017 or 2019) and build the program from the `CMakeLists.txt` file in the root directory of the repo.
+To compile the program on Windows, use Visual Studio (2015, 2017 or 2019) and build the program from the `CMakeLists.txt` file in the root directory of the repository.
 
-To compile the program on Linux, do as you please as long as the compiler supports C++17 as standard and the `-lpthread` option, since the `cpphttplib` uses `thread`.
+To compile the program on Linux, do as you please as long as the compiler supports the C++17 standard and threads, since the main library and `cpphttplib` make use of threads. Optionally to compile directly with G++, run the `run_with_gcc.sh` file in the repository's root directory.
+
+### How to test:
+`cd` to the `unittests` directory and run `run_unittests.sh`. **Any other files that should be tested by the unit tests have to be added to the script.**
 
 ### Guidelines:
 - Any files that are not required to compile the program and/or are not part of the usage at all, **should not be included in the version control system. This will be reviewed in any pull request**;

--- a/black_marlin.cpp
+++ b/black_marlin.cpp
@@ -3,11 +3,6 @@
 #include <iostream>
 #include <thread>
 
-void BlackMarlin::DeleteIn(const std::string& p_key, const int& p_seconds) {
-	std::this_thread::sleep_for(std::chrono::seconds(p_seconds));
-	this->Delete(p_key);
-}
-
 BlackMarlin::BlackMarlin() {
 	this->m_dict = std::unordered_map<std::string, std::string*>();
 }
@@ -41,9 +36,14 @@ void BlackMarlin::SetWithTimer(std::string p_key, std::string*& p_value, const i
 
 	if (it == this->m_dict.end()) {
 		this->m_dict[p_key] = p_value;
-		std::thread new_timer_thread(&BlackMarlin::DeleteIn, this, p_key, p_seconds);
-		new_timer_thread.detach();
+		std::thread timer_thread(&BlackMarlin::DeleteIn, this, p_key, p_seconds);
+		timer_thread.detach();
 	}
+}
+
+void BlackMarlin::DeleteIn(const std::string& p_key, const int& p_seconds) {
+	std::this_thread::sleep_for(std::chrono::seconds(p_seconds));
+	this->Delete(p_key);
 }
 
 void BlackMarlin::Overwrite(std::string p_key, std::string*& p_value) {

--- a/black_marlin.cpp
+++ b/black_marlin.cpp
@@ -1,6 +1,12 @@
 #include "black_marlin.hpp"
 #include <vector>
 #include <iostream>
+#include <thread>
+
+void BlackMarlin::DeleteIn(const std::string& p_key, const int& p_seconds) {
+	std::this_thread::sleep_for(std::chrono::seconds(p_seconds));
+	this->Delete(p_key);
+}
 
 BlackMarlin::BlackMarlin() {
 	this->m_dict = std::unordered_map<std::string, std::string*>();
@@ -10,40 +16,52 @@ BlackMarlin::~BlackMarlin() {
 	this->Flush();
 }
 
-std::string BlackMarlin::Get(const std::string& p_key) const {
-    auto it = this->m_dict.find(p_key);
+std::string* BlackMarlin::Get(const std::string& p_key) const {
+	auto it = this->m_dict.find(p_key);
 
-    if (it != this->m_dict.end()) {
-        return *it->second;
-    }
+	if (it != this->m_dict.end()) {
+		return it->second;
+	}
 
-    return "";
+	return nullptr;
 }
 
-void BlackMarlin::Set(std::string p_key, std::string* p_value) {
-    auto it = this->m_dict.find(p_key);
+void BlackMarlin::Set(std::string p_key, std::string*& p_value) {
+	auto it = this->m_dict.find(p_key);
 
-    if (it == this->m_dict.end()) {
-        this->m_dict[p_key] = p_value;
-    }
+	if (it == this->m_dict.end()) {
+		this->m_dict[p_key] = p_value;
+	}
 }
 
-void BlackMarlin::Overwrite(std::string p_key, std::string* p_value) {
-    auto it = this->m_dict.find(p_key);
+void BlackMarlin::SetWithTimer(std::string p_key, std::string*& p_value, const int& p_seconds) {
+	auto& p_dict = this->m_dict;
 
-    if (it != this->m_dict.end()) {
-        delete this->m_dict[p_key];
-        this->m_dict[p_key] = p_value;
-    }
+	auto it = this->m_dict.find(p_key);
+
+	if (it == this->m_dict.end()) {
+		this->m_dict[p_key] = p_value;
+		std::thread new_timer_thread(&BlackMarlin::DeleteIn, this, p_key, p_seconds);
+		new_timer_thread.detach();
+	}
+}
+
+void BlackMarlin::Overwrite(std::string p_key, std::string*& p_value) {
+	auto it = this->m_dict.find(p_key);
+
+	if (it != this->m_dict.end()) {
+		delete m_dict[p_key];
+		m_dict[p_key] = p_value;
+	}
 }
 
 void BlackMarlin::Delete(const std::string& p_key) {
-    auto it = this->m_dict.find(p_key);
+	auto it = this->m_dict.find(p_key);
 
-    if (it == this->m_dict.end()) return;
+	if (it == this->m_dict.end()) return;
 
-    delete this->m_dict[p_key];
-    
+	delete this->m_dict[p_key];
+
 	this->m_dict.erase(p_key);
 }
 
@@ -66,15 +84,18 @@ void BlackMarlin::Flush() {
 }
 
 void BlackMarlin::ClearDict() {
-    for (auto it = this->m_dict.begin(); it != this->m_dict.end(); ++it) {
-        delete this->m_dict[it->first];
-        /*
-         * At this point, "this->m_dict[it->first]" has to point to NULL so that it won't throw a heap corruption error. 
-         * This happens because the iterator might call its value or check for a value in the key. This ends up as an invalid read.
-         * Since the read checks for NULL first, the pointers must be set to NULL before any further operation, indicating that a pointer is not pointing to a valid memory region anymore.
-        */
-        this->m_dict[it->first] = NULL;
-    }
+	for (auto it = this->m_dict.begin(); it != this->m_dict.end(); ++it) {
+		auto& current_key = this->m_dict[it->first];
 
-    this->m_dict.clear();
+		delete current_key;
+
+		/*
+		 * At this point, "this->m_dict[it->first]" has to point to nullptr so that it won't throw a heap corruption error.
+		 * This happens because the iterator might call its value or check for a value in the key. This ends up as an invalid read.
+		 * Since the read checks for nullptr first, the pointers must be set to nullptr before any further operation, indicating that a pointer is not pointing to a valid memory region anymore.
+		 */
+		current_key = nullptr;
+	}
+
+	this->m_dict.clear();
 }

--- a/black_marlin.cpp
+++ b/black_marlin.cpp
@@ -21,7 +21,7 @@ std::string* BlackMarlin::Get(const std::string& p_key) const {
 	return nullptr;
 }
 
-void BlackMarlin::Set(std::string p_key, std::string*& p_value) {
+void BlackMarlin::Set(std::string p_key, std::string* p_value) {
 	auto it = this->m_dict.find(p_key);
 
 	if (it == this->m_dict.end()) {
@@ -29,7 +29,7 @@ void BlackMarlin::Set(std::string p_key, std::string*& p_value) {
 	}
 }
 
-void BlackMarlin::SetWithTimer(std::string p_key, std::string*& p_value, const uint16_t& p_seconds) {
+void BlackMarlin::SetToDeleteLater(std::string p_key, std::string* p_value, const uint16_t& p_seconds) {
 	auto& p_dict = this->m_dict;
 
 	auto it = this->m_dict.find(p_key);
@@ -47,12 +47,15 @@ void BlackMarlin::DeleteIn(const std::string& p_key, const uint16_t& p_seconds) 
 	this->Delete(p_key);
 }
 
-void BlackMarlin::Overwrite(std::string p_key, std::string*& p_value) {
+void BlackMarlin::Overwrite(std::string p_key, std::string* p_value) {
 	auto it = this->m_dict.find(p_key);
 
 	if (it != this->m_dict.end()) {
-		delete m_dict[p_key];
-		m_dict[p_key] = p_value;
+		auto& current = m_dict[p_key];
+
+		delete current;
+
+		current = p_value;
 	}
 }
 

--- a/black_marlin.hpp
+++ b/black_marlin.hpp
@@ -5,30 +5,30 @@
 #define BLACKMARLINCPP
 class BlackMarlin {
 public:
-    // BlackMarlin's default constructor.
+	// BlackMarlin's default constructor.
 	BlackMarlin();
-    // BlackMarlin's destructor.
+	// BlackMarlin's destructor.
 	~BlackMarlin();
-    // Returns the value of a key if it exists. If it does not exist, returns a nullptr.
+	// Returns the value of a key if it exists. If it does not exist, returns a nullptr.
 	std::string* Get(const std::string& p_key) const;
-    // Sets the key and the value in the map. If the key already exists and the intention was to overwrite the value, the method Overwrite should be used instead.
+	// Sets the key and the value in the map. If the key already exists and the intention was to overwrite the value, the method Overwrite should be used instead.
 	void Set(std::string p_key, std::string* p_value);
 	// Sets the key and the value in the map to be deleted later in the specified amount of seconds.
 	void SetToDeleteLater(std::string p_key, std::string* p_value, const uint16_t& p_seconds);
 	// Overwrites the value to the key. If the key does not exist, nothing happens.
 	void Overwrite(std::string p_key, std::string* p_value);
-    // Deletes the pointer to the string and the "bucket" in the map.
+	// Deletes the pointer to the string and the "bucket" in the map.
 	void Delete(const std::string& p_key);
 	// Deletes the pointer in the specified time in seconds.
 	void DeleteIn(const std::string& p_key, const uint16_t& p_seconds);
-    // Returns true if the key exists in the map; false otherwise.
+	// Returns true if the key exists in the map; false otherwise.
 	bool Exists(const std::string& p_key) const;
 	// Returns the number of items in the map.
 	size_t Count() const;
-    // Frees all pointers and buckets in the map.
+	// Frees all pointers and buckets in the map.
 	void Flush();
 private:
-    // The main std::unordered_map for storing the values (string to string pointer).
+	// The main std::unordered_map for storing the values (string to string pointer).
 	std::unordered_map<std::string, std::string*> m_dict;
 };
 #endif

--- a/black_marlin.hpp
+++ b/black_marlin.hpp
@@ -14,13 +14,13 @@ public:
     // Sets the key and the value in the map. If the key already exists and the intention was to overwrite the value, the method Overwrite should be used instead.
 	void Set(std::string p_key, std::string*& p_value);
 	// Sets the key and the value in the map to be deleted in the specified seconds.
-	void SetWithTimer(std::string p_key, std::string*& p_value, const int& p_seconds);
+	void SetWithTimer(std::string p_key, std::string*& p_value, const uint16_t& p_seconds);
 	// Overwrites the value to the key. If the key does not exist, nothing happens.
 	void Overwrite(std::string p_key, std::string*& p_value);
     // Deletes the pointer to the string and the "bucket" in the map.
 	void Delete(const std::string& p_key);
 	// Deletes the pointer in the specified time in seconds.
-	void DeleteIn(const std::string& p_key, const int& p_seconds);
+	void DeleteIn(const std::string& p_key, const uint16_t& p_seconds);
     // Returns true if the key exists in the map; false otherwise.
 	bool Exists(const std::string& p_key) const;
     // Returns the number of items in the map.
@@ -30,6 +30,4 @@ public:
 private:
     // The main std::unordered_map for storing the values (string to string pointer).
 	std::unordered_map<std::string, std::string*> m_dict;
-    // Clears the map. Is called in Flush and when destructing the object.
-	void ClearDict();
 };

--- a/black_marlin.hpp
+++ b/black_marlin.hpp
@@ -9,14 +9,18 @@ public:
 	BlackMarlin();
     // BlackMarlin's destructor.
 	~BlackMarlin();
-    // Returns the value of a key if it exists. If it does not exist, returns an empty string.
-	std::string Get(const std::string& p_key) const;
+    // Returns the value of a key if it exists. If it does not exist, returns a nullptr.
+	std::string* Get(const std::string& p_key) const;
     // Sets the key and the value in the map. If the key already exists and the intention was to overwrite the value, the method Overwrite should be used instead.
-	void Set(std::string p_key, std::string* p_value);
+	void Set(std::string p_key, std::string*& p_value);
+	// Sets the key and the value in the map to be deleted in the specified seconds.
+	void SetWithTimer(std::string p_key, std::string*& p_value, const int& seconds);
 	// Overwrites the value to the key. If the key does not exist, nothing happens.
-	void Overwrite(std::string p_key, std::string* p_value);
+	void Overwrite(std::string p_key, std::string*& p_value);
     // Deletes the pointer to the string and the "bucket" in the map.
 	void Delete(const std::string& p_key);
+	// Deletes the pointer in the specified time in milliseconds.
+	void DeleteIn(const std::string& p_key, const int& milliseconds);
     // Returns true if the key exists in the map; false otherwise.
 	bool Exists(const std::string& p_key) const;
     // Returns the number of items in the map.

--- a/black_marlin.hpp
+++ b/black_marlin.hpp
@@ -1,8 +1,8 @@
-#pragma once
-
 #include <unordered_map>
 #include <vector>
 
+#ifndef BLACKMARLINCPP
+#define BLACKMARLINCPP
 class BlackMarlin {
 public:
     // BlackMarlin's default constructor.
@@ -12,18 +12,18 @@ public:
     // Returns the value of a key if it exists. If it does not exist, returns a nullptr.
 	std::string* Get(const std::string& p_key) const;
     // Sets the key and the value in the map. If the key already exists and the intention was to overwrite the value, the method Overwrite should be used instead.
-	void Set(std::string p_key, std::string*& p_value);
-	// Sets the key and the value in the map to be deleted in the specified seconds.
-	void SetWithTimer(std::string p_key, std::string*& p_value, const uint16_t& p_seconds);
+	void Set(std::string p_key, std::string* p_value);
+	// Sets the key and the value in the map to be deleted later in the specified amount of seconds.
+	void SetToDeleteLater(std::string p_key, std::string* p_value, const uint16_t& p_seconds);
 	// Overwrites the value to the key. If the key does not exist, nothing happens.
-	void Overwrite(std::string p_key, std::string*& p_value);
+	void Overwrite(std::string p_key, std::string* p_value);
     // Deletes the pointer to the string and the "bucket" in the map.
 	void Delete(const std::string& p_key);
 	// Deletes the pointer in the specified time in seconds.
 	void DeleteIn(const std::string& p_key, const uint16_t& p_seconds);
     // Returns true if the key exists in the map; false otherwise.
 	bool Exists(const std::string& p_key) const;
-    // Returns the number of items in the map.
+	// Returns the number of items in the map.
 	size_t Count() const;
     // Frees all pointers and buckets in the map.
 	void Flush();
@@ -31,3 +31,4 @@ private:
     // The main std::unordered_map for storing the values (string to string pointer).
 	std::unordered_map<std::string, std::string*> m_dict;
 };
+#endif

--- a/black_marlin.hpp
+++ b/black_marlin.hpp
@@ -14,13 +14,13 @@ public:
     // Sets the key and the value in the map. If the key already exists and the intention was to overwrite the value, the method Overwrite should be used instead.
 	void Set(std::string p_key, std::string*& p_value);
 	// Sets the key and the value in the map to be deleted in the specified seconds.
-	void SetWithTimer(std::string p_key, std::string*& p_value, const int& seconds);
+	void SetWithTimer(std::string p_key, std::string*& p_value, const int& p_seconds);
 	// Overwrites the value to the key. If the key does not exist, nothing happens.
 	void Overwrite(std::string p_key, std::string*& p_value);
     // Deletes the pointer to the string and the "bucket" in the map.
 	void Delete(const std::string& p_key);
-	// Deletes the pointer in the specified time in milliseconds.
-	void DeleteIn(const std::string& p_key, const int& milliseconds);
+	// Deletes the pointer in the specified time in seconds.
+	void DeleteIn(const std::string& p_key, const int& p_seconds);
     // Returns true if the key exists in the map; false otherwise.
 	bool Exists(const std::string& p_key) const;
     // Returns the number of items in the map.

--- a/http_request_handler.cpp
+++ b/http_request_handler.cpp
@@ -1,8 +1,9 @@
 #include <string>
-#include "http_request_handler.hpp"
+#include "util.hpp"
 #include "httplib.h"
-#include "black_marlin.hpp"
 #include "status_code.hpp"
+#include "black_marlin.hpp"
+#include "http_request_handler.hpp"
 
 void HttpRequestHandler::HandleGet(const BlackMarlin& p_black_marlin, const httplib::Request& p_req, httplib::Response& p_res) const {
 	if (!p_req.has_param("key")) {
@@ -12,12 +13,12 @@ void HttpRequestHandler::HandleGet(const BlackMarlin& p_black_marlin, const http
 
 	auto value = p_black_marlin.Get(p_req.get_param_value("key"));
 
-	if (std::empty(value)) {
+	if (value == nullptr || std::empty(*value)) {
 		p_res.status = (int)StatusCode::kNoContent;
 		return;
 	}
 
-	p_res.set_content(value, this->m_content_type);
+	p_res.set_content(*value, this->m_content_type);
 }
 
 void HttpRequestHandler::HandlePost(BlackMarlin& p_black_marlin, const httplib::Request& p_req, httplib::Response& p_res) {
@@ -35,7 +36,21 @@ void HttpRequestHandler::HandlePost(BlackMarlin& p_black_marlin, const httplib::
 
     std::string* req_body_ptr = new std::string(p_req.body);
 
-    p_black_marlin.Set(key, req_body_ptr);
+	if (p_req.has_param("s")) {
+		const int seconds = Util::TryConvertStringToInt(p_req.get_param_value("s"));
+
+		if (seconds == 0) {
+			p_res.status = (int)StatusCode::kBadRequest;
+			delete req_body_ptr;
+			return;
+		}
+
+		p_black_marlin.SetWithTimer(key, req_body_ptr, seconds);
+	} 
+	else {
+		p_black_marlin.Set(key, req_body_ptr);
+	}
+
     p_res.status = (int)StatusCode::kCreated;
 }
 

--- a/http_request_handler.cpp
+++ b/http_request_handler.cpp
@@ -36,16 +36,16 @@ void HttpRequestHandler::HandlePost(BlackMarlin& p_black_marlin, const httplib::
 
     std::string* req_body_ptr = new std::string(p_req.body);
 
-	if (p_req.has_param("s")) {
-		std::string& seconds_string = p_req.get_param_value("s");
+	if (p_req.has_param("expiresin")) {
+		std::string& expires_in_seconds = p_req.get_param_value("expiresin");
 
-		if (!this->IsValidSecondsParam(seconds_string)) {
+		if (!this->IsValidSecondsParam(expires_in_seconds)) {
 			p_res.status = (int)StatusCode::kBadRequest;
 			delete req_body_ptr;
 			return;
 		}
 
-		const uint16_t& seconds = Util::TryCastStringToUnsignedShortInt(p_req.get_param_value("s"));
+		const uint16_t& seconds = Util::TryCastStringToUnsignedShortInt(expires_in_seconds);
 
 		p_black_marlin.SetWithTimer(key, req_body_ptr, seconds);
 	} 
@@ -56,11 +56,10 @@ void HttpRequestHandler::HandlePost(BlackMarlin& p_black_marlin, const httplib::
     p_res.status = (int)StatusCode::kCreated;
 }
 
-bool HttpRequestHandler::IsValidSecondsParam(std::string p_seconds_param) {
-	const uint16_t maxOfUint16 = 65535;
-	const int seconds = Util::TryCastStringToInt(p_seconds_param);
+bool HttpRequestHandler::IsValidSecondsParam(std::string p_expires_in_seconds_param) {
+	const int& seconds = Util::TryCastStringToInt(p_expires_in_seconds_param);
 
-	if (seconds <= 0 || seconds > maxOfUint16) {
+	if (seconds <= 0 || seconds > USHRT_MAX) {
 		return false;
 	}
 

--- a/http_request_handler.cpp
+++ b/http_request_handler.cpp
@@ -37,7 +37,7 @@ void HttpRequestHandler::HandlePost(BlackMarlin& p_black_marlin, const httplib::
     std::string* req_body_ptr = new std::string(p_req.body);
 
 	if (p_req.has_param("expiresin")) {
-		std::string& expires_in_seconds = p_req.get_param_value("expiresin");
+		std::string expires_in_seconds = p_req.get_param_value("expiresin");
 
 		if (!this->IsValidSecondsParam(expires_in_seconds)) {
 			p_res.status = (int)StatusCode::kBadRequest;
@@ -45,9 +45,9 @@ void HttpRequestHandler::HandlePost(BlackMarlin& p_black_marlin, const httplib::
 			return;
 		}
 
-		const uint16_t& seconds = Util::TryCastStringToUnsignedShortInt(expires_in_seconds);
+		const auto& seconds = Util::TryCastStringToInt(expires_in_seconds);
 
-		p_black_marlin.SetWithTimer(key, req_body_ptr, seconds);
+		p_black_marlin.SetToDeleteLater(key, req_body_ptr, seconds);
 	} 
 	else {
 		p_black_marlin.Set(key, req_body_ptr);

--- a/http_request_handler.cpp
+++ b/http_request_handler.cpp
@@ -34,7 +34,7 @@ void HttpRequestHandler::HandlePost(BlackMarlin& p_black_marlin, const httplib::
 		return;
 	}
 
-    std::string* req_body_ptr = new std::string(p_req.body);
+	std::string* req_body_ptr = new std::string(p_req.body);
 
 	if (p_req.has_param("expiresin")) {
 		std::string expires_in_seconds = p_req.get_param_value("expiresin");
@@ -48,12 +48,12 @@ void HttpRequestHandler::HandlePost(BlackMarlin& p_black_marlin, const httplib::
 		const auto& seconds = Util::TryCastStringToInt(expires_in_seconds);
 
 		p_black_marlin.SetToDeleteLater(key, req_body_ptr, seconds);
-	} 
+	}
 	else {
 		p_black_marlin.Set(key, req_body_ptr);
 	}
 
-    p_res.status = (int)StatusCode::kCreated;
+	p_res.status = (int)StatusCode::kCreated;
 }
 
 bool HttpRequestHandler::IsValidSecondsParam(std::string p_expires_in_seconds_param) {
@@ -79,8 +79,8 @@ void HttpRequestHandler::HandlePutAndPatch(BlackMarlin& p_black_marlin, const ht
 		return;
 	}
 
-    std::string* req_body_ptr = new std::string(p_req.body);
-    p_black_marlin.Overwrite(key, req_body_ptr);
+	std::string* req_body_ptr = new std::string(p_req.body);
+	p_black_marlin.Overwrite(key, req_body_ptr);
 }
 
 void HttpRequestHandler::HandleDelete(BlackMarlin& p_black_marlin, const httplib::Request& p_req, httplib::Response& p_res) {

--- a/http_request_handler.cpp
+++ b/http_request_handler.cpp
@@ -37,13 +37,15 @@ void HttpRequestHandler::HandlePost(BlackMarlin& p_black_marlin, const httplib::
     std::string* req_body_ptr = new std::string(p_req.body);
 
 	if (p_req.has_param("s")) {
-		const int seconds = Util::TryConvertStringToInt(p_req.get_param_value("s"));
+		std::string& seconds_string = p_req.get_param_value("s");
 
-		if (seconds == 0) {
+		if (!this->IsValidSecondsParam(seconds_string)) {
 			p_res.status = (int)StatusCode::kBadRequest;
 			delete req_body_ptr;
 			return;
 		}
+
+		const uint16_t& seconds = Util::TryCastStringToUnsignedShortInt(p_req.get_param_value("s"));
 
 		p_black_marlin.SetWithTimer(key, req_body_ptr, seconds);
 	} 
@@ -52,6 +54,17 @@ void HttpRequestHandler::HandlePost(BlackMarlin& p_black_marlin, const httplib::
 	}
 
     p_res.status = (int)StatusCode::kCreated;
+}
+
+bool HttpRequestHandler::IsValidSecondsParam(std::string p_seconds_param) {
+	const uint16_t maxOfUint16 = 65535;
+	const int seconds = Util::TryCastStringToInt(p_seconds_param);
+
+	if (seconds <= 0 || seconds > maxOfUint16) {
+		return false;
+	}
+
+	return true;
 }
 
 void HttpRequestHandler::HandlePutAndPatch(BlackMarlin& p_black_marlin, const httplib::Request& p_req, httplib::Response& p_res) {

--- a/http_request_handler.hpp
+++ b/http_request_handler.hpp
@@ -22,4 +22,5 @@ public:
 private:
     // Content-Type header value if needed.
     const char* m_content_type = "*/*; charset=utf-8";
+    bool IsValidSecondsParam(std::string p_seconds_param);
 };

--- a/http_request_handler.hpp
+++ b/http_request_handler.hpp
@@ -5,23 +5,23 @@
 #define HTTPREQUESTHANDLERCPP
 class HttpRequestHandler {
 public:
-    // Handles a Get request.
-    void HandleGet(const BlackMarlin& p_blackMarlin, const httplib::Request& p_req, httplib::Response& p_res) const;
-    // Handles a Post request.
-    void HandlePost(BlackMarlin& p_blackMarlin, const httplib::Request& p_req, httplib::Response& p_res);
-    // Handles Put and Patch requests.
-    void HandlePutAndPatch(BlackMarlin& p_blackMarlin, const httplib::Request& p_req, httplib::Response& p_res);
-    // Handles a Delete request.
-    void HandleDelete(BlackMarlin& p_blackMarlin, const httplib::Request& p_req, httplib::Response& p_res);
-    // Handles a Delete request in the "/flush" route.
-    void HandleDeleteFlush(BlackMarlin& p_blackMarlin, httplib::Response& p_res);
-    // Handles a Get request in the "/exists" route.
-    void HandleGetExists(const BlackMarlin& p_blackMarlin, const httplib::Request& p_req, httplib::Response& p_res) const;
-    // Handles a Get request in the "/count" route.
-    void HandleGetCount(const BlackMarlin& p_blackMarlin, httplib::Response& p_res) const;
+	// Handles a Get request.
+	void HandleGet(const BlackMarlin& p_blackMarlin, const httplib::Request& p_req, httplib::Response& p_res) const;
+	// Handles a Post request.
+	void HandlePost(BlackMarlin& p_blackMarlin, const httplib::Request& p_req, httplib::Response& p_res);
+	// Handles Put and Patch requests.
+	void HandlePutAndPatch(BlackMarlin& p_blackMarlin, const httplib::Request& p_req, httplib::Response& p_res);
+	// Handles a Delete request.
+	void HandleDelete(BlackMarlin& p_blackMarlin, const httplib::Request& p_req, httplib::Response& p_res);
+	// Handles a Delete request in the "/flush" route.
+	void HandleDeleteFlush(BlackMarlin& p_blackMarlin, httplib::Response& p_res);
+	// Handles a Get request in the "/exists" route.
+	void HandleGetExists(const BlackMarlin& p_blackMarlin, const httplib::Request& p_req, httplib::Response& p_res) const;
+	// Handles a Get request in the "/count" route.
+	void HandleGetCount(const BlackMarlin& p_blackMarlin, httplib::Response& p_res) const;
 private:
-    // Content-Type header value if needed.
-    const char* m_content_type = "*/*; charset=utf-8";
-    bool IsValidSecondsParam(std::string p_seconds_param);
+	// Content-Type header value if needed.
+	const char* m_content_type = "*/*; charset=utf-8";
+	bool IsValidSecondsParam(std::string p_seconds_param);
 };
 #endif

--- a/http_request_handler.hpp
+++ b/http_request_handler.hpp
@@ -1,8 +1,8 @@
-#pragma once
-
 #include "httplib.h"
 #include "black_marlin.hpp"
 
+#ifndef HTTPREQUESTHANDLERCPP
+#define HTTPREQUESTHANDLERCPP
 class HttpRequestHandler {
 public:
     // Handles a Get request.
@@ -24,3 +24,4 @@ private:
     const char* m_content_type = "*/*; charset=utf-8";
     bool IsValidSecondsParam(std::string p_seconds_param);
 };
+#endif

--- a/main.cpp
+++ b/main.cpp
@@ -47,10 +47,8 @@ int main() {
 	const char* address = "127.0.0.1";
 	int port = 7000;
 
-	std::cout << "Listening at: " << address << ":" << port << std::endl;
-	server.listen(address, port);
-
-	black_marlin.~BlackMarlin();
+	std::cout << "Listening at: " << address << ":" << port << "\n";
+    server.listen(address, port);
 
 	return EXIT_SUCCESS;
 }

--- a/run_with_gcc.sh
+++ b/run_with_gcc.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 g++ -pthread -std=c++17 black_marlin.cpp black_marlin.hpp httplib.h main.cpp http_request_handler.cpp http_request_handler.hpp util.hpp util.cpp -o black_marlin
-valgrind --leak-check=full ./black_marlin
+./black_marlin

--- a/run_with_gcc.sh
+++ b/run_with_gcc.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+g++ -pthread -std=c++17 black_marlin.cpp black_marlin.hpp httplib.h main.cpp http_request_handler.cpp http_request_handler.hpp util.hpp util.cpp -o black_marlin
+./black_marlin

--- a/run_with_gcc.sh
+++ b/run_with_gcc.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 g++ -pthread -std=c++17 black_marlin.cpp black_marlin.hpp httplib.h main.cpp http_request_handler.cpp http_request_handler.hpp util.hpp util.cpp -o black_marlin
-./black_marlin
+valgrind --leak-check=full ./black_marlin

--- a/unittests/black_marlin_tests.cpp
+++ b/unittests/black_marlin_tests.cpp
@@ -5,16 +5,14 @@
 
 auto black_marlin = BlackMarlin();
 
-std::string* deletable_val = new std::string("get and set test");
-std::string* sample_key = new std::string("get and set test");
-std::string* val = new std::string("get and set test two");
-
 TEST_CASE("Black Marlin Get and Set Tests", "[Get and Set]")
 {
 	std::cout << "Running Get and Set - Set should create a key-value pair in the map and get should return the value associated to the key.\n";
 
-	black_marlin.Set(*sample_key, deletable_val);
-	std::string* value = black_marlin.Get(*sample_key);
+	std::string* deletable_val = new std::string("get and set test");
+	std::string sample_key = "get and set test";
+	black_marlin.Set(sample_key, deletable_val);
+	std::string* value = black_marlin.Get(sample_key);
 
 	REQUIRE(*value != "");
 	REQUIRE(*value == "get and set test");
@@ -28,7 +26,7 @@ TEST_CASE("Set with timer tests", "[Set with timer]")
 	std::string key = "get and set with timer test";
 	std::string* value = new std::string("get and set with timer test");
 
-	black_marlin.SetToDeleteLater(*sample_key, value, seconds);
+	black_marlin.SetToDeleteLater(key, value, seconds);
 
 	std::this_thread::sleep_for(std::chrono::seconds(6));
 
@@ -39,10 +37,12 @@ TEST_CASE("Set with timer tests", "[Set with timer]")
 TEST_CASE("Overwrite tests", "[Overwrite]")
 {
 	std::cout << "Running Overwrite - Should overwrite the value associated to the key.\n";
+	
+	std::string sample_key = "get and set test";
+	std::string* val = new std::string("get and set test two");
+	black_marlin.Overwrite(sample_key, val);
 
-	black_marlin.Overwrite(*sample_key, val);
-
-	std::string* value = black_marlin.Get(*sample_key);
+	std::string* value = black_marlin.Get(sample_key);
 
 	REQUIRE(*value == "get and set test two");
 }
@@ -70,7 +70,9 @@ TEST_CASE("Count Test", "[Count]")
 {
 	std::cout << "Running Count - Should return 1 after inserting a key.\n";
 
-	black_marlin.Set(*sample_key, sample_key);
+	std::string sample_key = "get and set test";
+	std::string* value = new std::string("test value");
+	black_marlin.Set(sample_key, value);
 
 	REQUIRE(black_marlin.Count() == 1);
 }
@@ -83,3 +85,4 @@ TEST_CASE("Flush Test", "[Flush]")
 
 	REQUIRE(black_marlin.Count() == 0);
 }
+

--- a/unittests/black_marlin_tests.cpp
+++ b/unittests/black_marlin_tests.cpp
@@ -1,46 +1,64 @@
 #define CATCH_CONFIG_MAIN
 #include "catch2.hpp"
 #include "../black_marlin.hpp"
+#include <thread>
 
-BlackMarlin black_marlin = BlackMarlin();
+auto black_marlin = BlackMarlin();
+
+std::string* deletable_val = new std::string("get and set test");
+std::string* sample_key = new std::string("get and set test");
+std::string* val = new std::string("get and set test two");
 
 TEST_CASE("Black Marlin Get and Set Tests", "[Get and Set]")
 {
-	std::cout << "Running Get and Set - Set should create a key-value pair in the map and get should return the value associated to the key." << std::endl;
+	std::cout << "Running Get and Set - Set should create a key-value pair in the map and get should return the value associated to the key.\n";
 
-	std::string sample_key = "get and set test";
+	black_marlin.Set(*sample_key, deletable_val);
+	std::string* value = black_marlin.Get(*sample_key);
 
-	black_marlin.Set(sample_key, &sample_key);
+	REQUIRE(*value != "");
+	REQUIRE(*value == "get and set test");
+}
 
-	std::string value = black_marlin.Get(sample_key);
-	REQUIRE(value != "");
-	REQUIRE(value == "get and set test");
+TEST_CASE("Set with timer tests", "[Set with timer]")
+{
+	const uint16_t seconds = 5;
+	std::cout << "Running Set with Timer - Should set a key to expire in five seconds, and the 'get' command after it should return nullptr.\n";
+
+	std::string key = "get and set with timer test";
+	std::string* value = new std::string("get and set with timer test");
+
+	black_marlin.SetToDeleteLater(*sample_key, value, seconds);
+
+	std::this_thread::sleep_for(std::chrono::seconds(6));
+
+	REQUIRE(!black_marlin.Exists(key));
+	REQUIRE(black_marlin.Get(key) == nullptr);
 }
 
 TEST_CASE("Overwrite tests", "[Overwrite]")
 {
-	std::cout << "Running Overwrite - Should overwrite the value associated to the key." << std::endl;
+	std::cout << "Running Overwrite - Should overwrite the value associated to the key.\n";
 
-	std::string sample_key = "get and set test";
-	std::string val = "get and set test two";
+	black_marlin.Overwrite(*sample_key, val);
 
-	black_marlin.Overwrite(sample_key, &val);
+	std::string* value = black_marlin.Get(*sample_key);
 
-	std::string value = black_marlin.Get(sample_key);
-	REQUIRE(value == "get and set test two");
+	REQUIRE(*value == "get and set test two");
 }
 
 TEST_CASE("Exists Tests", "[Exists]")
 {
-	std::cout << "Running Exists - Should return true." << std::endl;
+	std::cout << "Running Exists - Should return true.\n";
 
 	std::string key = "get and set test";
+
 	REQUIRE(black_marlin.Exists(key));
 }
 
 TEST_CASE("Delete Tests", "[Delete]")
 {
-	std::cout << "Running Delete - Delete should remove the key from the std::unordered_map and clear the std::string*." << std::endl;
+	std::cout << "Running Delete - Delete should remove the key from the std::unordered_map and clear the std::string*.\n";
 
 	std::string key = "get and set test";
 	black_marlin.Delete(key);
@@ -50,19 +68,18 @@ TEST_CASE("Delete Tests", "[Delete]")
 
 TEST_CASE("Count Test", "[Count]")
 {
-	std::cout << "Running Count - Should return 1 after inserting a key." << std::endl;
+	std::cout << "Running Count - Should return 1 after inserting a key.\n";
 
-	std::string sample_key = "get and set test";
-
-	black_marlin.Set(sample_key, &sample_key);
+	black_marlin.Set(*sample_key, sample_key);
 
 	REQUIRE(black_marlin.Count() == 1);
 }
 
 TEST_CASE("Flush Test", "[Flush]")
 {
-	std::cout << "Running Flush - Should run without heap corruption and Count should return 0." << std::endl;
+	std::cout << "Running Flush - Should run without heap corruption and Count should return 0.\n";
 
 	black_marlin.Flush();
+
 	REQUIRE(black_marlin.Count() == 0);
 }

--- a/unittests/run_unittests.sh
+++ b/unittests/run_unittests.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+g++ -pthread -std=c++11 ../black_marlin.hpp ../black_marlin.cpp ../util.hpp ../util.cpp catch2.hpp black_marlin_tests.cpp util_tests.cpp -o unittests
+./unittests

--- a/unittests/run_unittests.sh
+++ b/unittests/run_unittests.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 g++ -pthread -std=c++11 ../black_marlin.hpp ../black_marlin.cpp ../util.hpp ../util.cpp catch2.hpp black_marlin_tests.cpp util_tests.cpp -o unittests
-./unittests
+valgrind ./unittests

--- a/unittests/util_tests.cpp
+++ b/unittests/util_tests.cpp
@@ -1,0 +1,27 @@
+#include "catch2.hpp"
+#include "../util.hpp"
+#include <iostream>
+
+TEST_CASE("Util TryConvertStringToInt should return different from zero", "[TryConvertStringToInt]")
+{
+	std::string test = "234";
+	REQUIRE(Util::TryCastStringToInt(test) == 234);
+}
+
+TEST_CASE("TryConvertStringToUnsignedShortInt should return different from zero", "[TryConvertStringToUnsignedShortInt]")
+{
+	std::string test = "234";
+	REQUIRE(Util::TryCastStringToUnsignedShortInt(test) == 234);
+}
+
+TEST_CASE("Util TryConvertStringToInt test should return zero", "[TryConvertStringToInt]")
+{
+	std::string test = "ASDF";
+	REQUIRE(Util::TryCastStringToInt(test) == 0);
+}
+
+TEST_CASE("Util TryConvertStringToUnsignedShortInt test should return zero", "[TryConvertStringToUnsignedShortInt]")
+{
+	std::string test = "ASDFDFSFS";
+	REQUIRE(Util::TryCastStringToUnsignedShortInt(test) == 0);
+}

--- a/util.cpp
+++ b/util.cpp
@@ -1,0 +1,14 @@
+#include <string>
+#include "util.hpp"
+#include <iostream>
+
+int Util::TryConvertStringToInt(std::string& p_str) {
+	try {
+		return std::stoi(p_str);
+	}
+	catch (std::exception& ex) {
+		std::cout << "Tried convertion of invalid string to int. Exception message: " << ex.what() << "\n";
+	}
+
+	return 0;
+}

--- a/util.cpp
+++ b/util.cpp
@@ -1,6 +1,6 @@
 #include <string>
-#include "util.hpp"
 #include <iostream>
+#include "util.hpp"
 
 int Util::TryCastStringToInt(std::string& p_str) {
 	try {

--- a/util.cpp
+++ b/util.cpp
@@ -2,12 +2,29 @@
 #include "util.hpp"
 #include <iostream>
 
-int Util::TryConvertStringToInt(std::string& p_str) {
+int Util::TryCastStringToInt(std::string& p_str) {
 	try {
 		return std::stoi(p_str);
 	}
-	catch (std::exception& ex) {
-		std::cout << "Tried convertion of invalid string to int. Exception message: " << ex.what() << "\n";
+	catch (std::exception ex) {
+		std::cout << "Tried convertion of invalid std::string to int. Exception message: " << ex.what() << "\n";
+	}
+	catch (...) {
+		std::cout << "Tried convertion of invalid std::string to int. No std::exception thrown. " << "\n";
+	}
+
+	return 0;
+}
+
+uint16_t Util::TryCastStringToUnsignedShortInt(std::string& p_str) {
+	try {
+		return std::stoi(p_str);
+	}
+	catch (std::exception ex) {
+		std::cout << "Tried convertion of invalid std::string to uint16_t. Exception message: " << ex.what() << "\n";
+	}
+	catch (...) {
+		std::cout << "Tried convertion of invalid std::string to uint16_t. No std::exception thrown. " << "\n";
 	}
 
 	return 0;

--- a/util.hpp
+++ b/util.hpp
@@ -1,5 +1,8 @@
-#pragma once
+#include <cstdint>
+#include <string>
 
+#ifndef UTILCPP
+#define UTILCPP
 class Util {
 public:
 	// Tries casting a string to int. If not successful, returns 0.
@@ -7,3 +10,4 @@ public:
 	// Tries casting a string to an uint16_t. If not successful, returns 0.
 	static uint16_t TryCastStringToUnsignedShortInt(std::string& p_str);
 };
+#endif

--- a/util.hpp
+++ b/util.hpp
@@ -2,5 +2,8 @@
 
 class Util {
 public:
-	static int TryConvertStringToInt(std::string& p_str);
+	// Tries casting a string to int. If not successful, returns 0.
+	static int TryCastStringToInt(std::string& p_str);
+	// Tries casting a string to an uint16_t. If not successful, returns 0.
+	static uint16_t TryCastStringToUnsignedShortInt(std::string& p_str);
 };

--- a/util.hpp
+++ b/util.hpp
@@ -1,0 +1,6 @@
+#pragma once
+
+class Util {
+public:
+	static int TryConvertStringToInt(std::string& p_str);
+};


### PR DESCRIPTION
- Adding new feature to make key expire in an amount of seconds specified by a new `expiresin` query parameter;
- The main library now uses threads;
- The new parameter is optional;
- An expiring key can be overwritten or deleted if desired;
- Creating new bash scripts for compiling the program and its unit tests;
- Adding new `Util` class and tests for it;
- The unit tests now run with valgrind by default, which checks for memory leaks in the unit tests and in the files being tested.