### PR TITLE
Feature/refactoring log 20211003

### DIFF
--- a/HTTP/http_request_handler.cpp
+++ b/HTTP/http_request_handler.cpp
@@ -23,20 +23,6 @@ void HttpRequestHandler::HandleGet(const BlackMarlin& p_black_marlin, const http
 
         const auto& value = p_black_marlin.Get(p_req.get_param_value("key"));
 
-        char* log_message = static_cast<char *>(malloc(sizeof(char) * 200));
-
-        log_message = strcpy(log_message, "Get route. Key: ");
-
-        log_message = strcat(log_message, p_req.get_param_value("key").c_str());
-
-        log_message = strcat(log_message, " - Error: ");
-
-        log_message = strcat(log_message, "New testing OK.");
-
-        this->m_logger.Log(log_message);
-
-        free(log_message);
-
         if (std::empty(value))
         {
             p_res.status = static_cast<int>(StatusCode::kNoContent);

--- a/HTTP/http_request_handler.cpp
+++ b/HTTP/http_request_handler.cpp
@@ -23,6 +23,20 @@ void HttpRequestHandler::HandleGet(const BlackMarlin& p_black_marlin, const http
 
         const auto& value = p_black_marlin.Get(p_req.get_param_value("key"));
 
+        char* log_message = static_cast<char *>(malloc(sizeof(char) * 200));
+
+        log_message = strcpy(log_message, "Get route. Key: ");
+
+        log_message = strcat(log_message, p_req.get_param_value("key").c_str());
+
+        log_message = strcat(log_message, " - Error: ");
+
+        log_message = strcat(log_message, "New testing OK.");
+
+        this->m_logger.Log(log_message);
+
+        free(log_message);
+
         if (std::empty(value))
         {
             p_res.status = static_cast<int>(StatusCode::kNoContent);
@@ -34,8 +48,22 @@ void HttpRequestHandler::HandleGet(const BlackMarlin& p_black_marlin, const http
     catch (std::exception& e)
     {
         const auto& key = p_req.get_param_value("key");
-        this->m_logger.Log("Get route. Key: " + key + " - Error: " + std::string(e.what()));
+
+        char* log_message = static_cast<char *>(malloc(sizeof(char) * LOG_MESSAGE_SIZE));
+
+        log_message = strcpy(log_message, "Get route. Key: ");
+
+        log_message = strcat(log_message, key.c_str());
+
+        log_message = strcat(log_message, " - Error: ");
+
+        log_message = strcat(log_message, e.what());
+
+        this->m_logger.Log(log_message);
+
         p_res.status = static_cast<int>(StatusCode::kInternalServerError);
+
+        free(log_message);
     }
 }
 
@@ -85,10 +113,21 @@ void HttpRequestHandler::HandlePost(BlackMarlin& p_black_marlin, const httplib::
     catch (std::exception& e)
     {
         const auto& key = p_req.get_param_value("key");
-        const auto& value = p_req.get_param_value("value");
 
-        this->m_logger.Log("Post route. Key: " + key + " - Value: " + value + " - Error: " + std::string(e.what()));
+        char* log_message = static_cast<char *>(malloc(sizeof(char) * LOG_MESSAGE_SIZE));
+
+        log_message = strcpy(log_message, "Post route. Key: ");
+
+        log_message = strcat(log_message, key.c_str());
+
+        log_message = strcat(log_message, " - Error: ");
+
+        log_message = strcat(log_message, e.what());
+
+        this->m_logger.Log(log_message);
         p_res.status = static_cast<int>(StatusCode::kInternalServerError);
+
+        free(log_message);
     }
 }
 
@@ -128,8 +167,22 @@ void HttpRequestHandler::HandlePutAndPatch(BlackMarlin& p_black_marlin, const ht
     }
     catch (std::exception& e)
     {
-        this->m_logger.Log("Patch and Put route. Error: " + std::string(e.what()));
+        const auto& key = p_req.get_param_value("key");
+
+        char* log_message = static_cast<char *>(malloc(sizeof(char) * LOG_MESSAGE_SIZE));
+
+        log_message = strcpy(log_message, "Patch and Put route. Key: ");
+
+        log_message = strcat(log_message, key.c_str());
+
+        log_message = strcat(log_message, " - Error: ");
+
+        log_message = strcat(log_message, e.what());
+
+        this->m_logger.Log(log_message);
         p_res.status = static_cast<int>(StatusCode::kInternalServerError);
+
+        free(log_message);
     }
 }
 
@@ -148,8 +201,21 @@ void HttpRequestHandler::HandleDelete(BlackMarlin& p_black_marlin, const httplib
     catch (std::exception& e)
     {
         const auto& key = p_req.get_param_value("key");
-        this->m_logger.Log("Delete route. Key: " + key +" - Error: " + e.what());
+
+        char* log_message = static_cast<char *>(malloc(sizeof(char) * LOG_MESSAGE_SIZE));
+
+        log_message = strcpy(log_message, "Delete route. Key: ");
+
+        log_message = strcat(log_message, key.c_str());
+
+        log_message = strcat(log_message, " - Error: ");
+
+        log_message = strcat(log_message, e.what());
+
+        this->m_logger.Log(log_message);
         p_res.status = static_cast<int>(StatusCode::kInternalServerError);
+
+        free(log_message);
     }
 }
 
@@ -161,8 +227,16 @@ void HttpRequestHandler::HandleDeleteFlush(BlackMarlin& p_black_marlin, httplib:
     }
     catch (std::exception& e)
     {
-        this->m_logger.Log("Flush route. Error: " + std::string(e.what()));
+        char* log_message = static_cast<char *>(malloc(sizeof(char) * LOG_MESSAGE_SIZE));
+
+        log_message = strcpy(log_message, "Flush route. Error: ");
+
+        log_message = strcat(log_message, e.what());
+
+        this->m_logger.Log(log_message);
         p_res.status = static_cast<int>(StatusCode::kInternalServerError);
+
+        free(log_message);
     }
 }
 
@@ -184,8 +258,21 @@ void HttpRequestHandler::HandleGetExists(const BlackMarlin& p_black_marlin, cons
     catch (std::exception& e)
     {
         const auto& key = p_req.get_param_value("key");
-        this->m_logger.Log("Exists route. Key: " + key + " - Error: " + std::string(e.what()));
+
+        char* log_message = static_cast<char *>(malloc(sizeof(char) * LOG_MESSAGE_SIZE));
+
+        log_message = strcpy(log_message, "Exists route. Key: ");
+
+        log_message = strcat(log_message, key.c_str());
+
+        log_message = strcat(log_message, " - Error: ");
+
+        log_message = strcat(log_message, e.what());
+
+        this->m_logger.Log(log_message);
         p_res.status = static_cast<int>(StatusCode::kInternalServerError);
+
+        free(log_message);
     }
 }
 
@@ -197,8 +284,17 @@ void HttpRequestHandler::HandleGetCount(const BlackMarlin& p_black_marlin, httpl
     }
     catch (std::exception& e)
     {
-        this->m_logger.Log("Count route. Error: " + std::string(e.what()));
+        char* log_message = static_cast<char *>(malloc(sizeof(char) * LOG_MESSAGE_SIZE));
+
+        log_message = strcpy(log_message, "Count route. Error: ");
+
+        log_message = strcat(log_message, e.what());
+
+        this->m_logger.Log(log_message);
+
         p_res.status = static_cast<int>(StatusCode::kInternalServerError);
+
+        free(log_message);
     }
 }
 
@@ -215,6 +311,14 @@ void HttpRequestHandler::SetResponseHeadersFromConfig(httplib::Response& p_res) 
     }
     catch (std::exception& e)
     {
-        this->m_logger.Log("Error setting custom response headers: " + std::string(e.what()));
+        char* log_message = static_cast<char *>(malloc(sizeof(char) * LOG_MESSAGE_SIZE));
+
+        log_message = strcpy(log_message, "Error setting custom response headers: ");
+
+        log_message = strcat(log_message, e.what());
+
+        this->m_logger.Log(log_message);
+
+        free(log_message);
     }
 }

--- a/Logger/logger.cpp
+++ b/Logger/logger.cpp
@@ -17,17 +17,25 @@ Logger::~Logger()
     fclose(this->m_file);
 }
 
-void Logger::Log(const std::string& p_message) noexcept
+void Logger::Log(const char* p_message) noexcept
 {
     time_t now = time(0);
 
-    tm* current_local_time = localtime(&now);
+    const auto& current_local_time = localtime(&now);
 
-    char time_string_buffer[TIME_BUFFER_SIZE];
+    char* time_string_buffer = static_cast<char *>(malloc(sizeof(char) * TIME_STRING_SIZE));
 
-    strftime(time_string_buffer, sizeof(time_string_buffer), "%Y-%m-%d %X", current_local_time);
+    strftime(time_string_buffer, TIME_STRING_SIZE, "%Y-%m-%d %X", current_local_time);
 
-    const auto& final_log_message = strcat(time_string_buffer, LOG_MESSAGE_DELIMETER) + p_message + "\n";
+    time_string_buffer = strcat(time_string_buffer, LOG_MESSAGE_DELIMETER);
 
-    fputs(final_log_message.c_str(), this->m_file);
+    time_string_buffer = strcat(time_string_buffer, p_message);
+
+    time_string_buffer = strcat(time_string_buffer, "\n");
+
+    fputs(time_string_buffer, this->m_file);
+
+    fflush(this->m_file);
+
+    free(time_string_buffer);
 }

--- a/Logger/logger.hpp
+++ b/Logger/logger.hpp
@@ -10,8 +10,12 @@
 constexpr char LOG_FILENAME[] = "bm_logs.txt";
 // The log message delimeter. This separates the normal message with the time the error occurred.
 constexpr char LOG_MESSAGE_DELIMETER[] = " - ";
-// The time message buffer's size. Since we don't always know the size of a key or value, this value will vary in future versions.
-constexpr int TIME_BUFFER_SIZE = 100;
+// The size of the log message.
+// A key can easily exceed more than 200 characters considering it will almost always be some kind of big string or JSON structure.
+constexpr int LOG_MESSAGE_SIZE = 600;
+// The time message buffer's size. The size of the formatted time string including the size of the log message.
+constexpr int TIME_STRING_SIZE = LOG_MESSAGE_SIZE + 20;
+
 
 class Logger
 {
@@ -19,7 +23,7 @@ class Logger
         Logger();
         ~Logger();
         // Logs the message to the log file.
-        void Log(const std::string& p_message) noexcept;
+        void Log(const char* p_message) noexcept;
     private:
         // The "LOG_FILENAME"'s full path to allow writing.
         std::string m_full_filepath{};

--- a/PathHandler/path_handler.cpp
+++ b/PathHandler/path_handler.cpp
@@ -3,31 +3,16 @@
 #include <sstream>
 #include <iostream>
 
-#if _WIN32 || _WIN64
-
-#include <Windows.h>
-#define PATH_DELIMETER '\\'
-
-#else
-
 #include <unistd.h>
 #include <climits>
 #define PATH_DELIMETER '/'
-
-#endif
 
 std::string PathHandler::GetThisExecutingBinaryFullPath()
 {
     bool found_binary = false;
     std::string full_path, path_part, filename_part_to_look_for;
 
-#if defined(WIN32) || defined(__WIN32__) || defined(_WIN32) || defined(_MSC_VER) || defined(__MINGW32__) || defined(WIN64)
-
-    char path_buffer[MAX_PATH] = { '\0' };
-    filename_part_to_look_for = "blackmarlin.exe";
-    GetModuleFileName(NULL, path_buffer, MAX_PATH);
-
-#elif defined(linux) || defined(__linux) || defined(__linux__)
+#if defined(linux) || defined(__linux) || defined(__linux__)
 
     char path_buffer[PATH_MAX] = { '\0' };
     filename_part_to_look_for = "blackmarlin";

--- a/README.md
+++ b/README.md
@@ -12,13 +12,10 @@ This also allows servers in an architecture that uses Load Balancing to share ke
 
 
 ## Features:
-- It is currently using an `std::unordered_map` to store the keys and values;
 - The main library is covered by unit tests with [catchv2](https://github.com/catchorg/Catch2);
 - REST API interface for HTTP methods written on top of the main library with [cpp-httplib](https://github.com/yhirose/cpp-httplib);
-- Integration tests are made to insure that every route is working (the integration tests will be in the version control of this repository in the near future);
-- Performance profiling and memory leak checks;
-- Allows custom response headers;
-- Compatible with Windows and Linux servers (check below in the "how to compile" and in the "releases" tab for more information on Windows releases).
+- Integration tests are made to insure that every route is working as intended. This repository has a Postman collection with a really big JSON file you can use to test its performance;
+- Allows custom response headers and port.
 
 ## Usage:
 The program runs on port **7000** by default. You can test it by making a GET request to "http://127.0.0.1:7000/count" with your program running, for example. It should return `200 - OK` with `0` in the response body (assuming you didn't have any keys cached by Black Marlin prior to calling this route). The only thing you have to do to integrate it with your application is make HTTP requests and handle its responses.
@@ -30,13 +27,7 @@ If you want Black Marlin to be available via a port of your choice, you can run 
 
 `./blackmarlin 8534`
 
-or 
-
-`./blackmarlin.exe 8534`
-
-depending on the release you're using.
-
-Note that if the port argument is an invalid value the program will not run and an error message will be printed to STDOUT.
+Note that if the port argument is an invalid value the program will not run and an error message will be written to STDOUT.
 
 --------------------------
 
@@ -115,7 +106,8 @@ To disable this behavior just delete/remove the file mentioned and the server wi
 ---------------------------
 
 ### Logs:
-Everytime an error occurs it is written to a file called `bm_logs.txt` (its created if it doesn't already exist in the same directory as the program).
+Everytime an error occurs it is written to a file called `bm_logs.txt` (it is created if it doesn't already exist in the same directory). Every log message will have the following format:
+
 `{Year}-{Month}-{Day} {Hour}:{Minute}:{Second} - {ErrorMessage}`
 
 ---------------------------
@@ -126,8 +118,8 @@ Everytime an error occurs it is written to a file called `bm_logs.txt` (its crea
 ---------------------------
 
 ### Sidenotes:
-- This program does NOT support any other operating system except for Windows (last release) and Linux (current and past releases); If you try to run it on MacOS for example, the program will not run.
-- **There is a pre-release available for testing!**
+- This program does NOT officially support any other operating system except for Linux. If you try to run it on a Mac OS for example, the program will not run.
+- **The first official release is available!**
 
 ---------------------------
 
@@ -137,13 +129,10 @@ Everytime an error occurs it is written to a file called `bm_logs.txt` (its crea
 Feel free to open issues and fork as you feel like it. I'll be happy to help in any case.
 
 ### How to compile:
-The program can be compiled in any way as long as it supports threads (expiring keys in the main library and `cpphttplib`) and the C++17 standard. The recommended way to compile the program is by using CMake. It is already configured in the repo and can be done both on Windows and Linux.
-
-As of now, the current Windows version does not support the OpenSSL library and therefore is not available in the current release.
-After giving it some thought, maybe there is no need for Windows support at all given the current state of the Web and the amount of servers using only Linux. **This is still being reviewed and should not be consired true for all subsequent releases**.
+The program can be compiled in any way as long as it supports threads (expiring keys in the main library and `cpphttplib`), is targeting the C++17 standard and includes OpenSSL. The recommended way to compile the program is using CMake. It is already configured in the repo and can be done both on Windows and Linux.
 
 ### How to test:
-`cd` to `unittests` directory and run the `run_unittests.sh` bash file. **Any other modules to be tested have to be added to the file mentioned**.
+`cd` to `unittests` directory and run the `run_unittests.sh` bash file. **Any other modules to be tested have to be added to the mentioned file**.
 
 ### Guidelines:
 - Please follow the code's pattern; keeping the code looking the same everywhere in the program makes it easier to change stuff.

--- a/Util/util.cpp
+++ b/Util/util.cpp
@@ -2,9 +2,8 @@
 #include <iostream>
 #include "util.hpp"
 
-void Util::Panic(const std::string& p_panic_message) noexcept
+void Util::Panic(const char* p_panic_message) noexcept
 {
     std::cout << p_panic_message;
-    this->m_logger.Log(p_panic_message);
     exit(1);
 }

--- a/Util/util.cpp
+++ b/Util/util.cpp
@@ -2,7 +2,7 @@
 #include <iostream>
 #include "util.hpp"
 
-void Util::Panic(const char* p_panic_message) noexcept
+void Util::Panic(const std::string& p_panic_message) noexcept
 {
     std::cout << p_panic_message;
     exit(1);

--- a/Util/util.hpp
+++ b/Util/util.hpp
@@ -9,7 +9,7 @@ class Util
 {
     public:
         // Writes a message to STDOUT, logs and ends the program's execution.
-        void Panic(const char* p_panic_message) noexcept;
+        void Panic(const std::string& p_panic_message) noexcept;
     private:
         Logger m_logger;
 };

--- a/Util/util.hpp
+++ b/Util/util.hpp
@@ -9,7 +9,7 @@ class Util
 {
     public:
         // Writes a message to STDOUT, logs and ends the program's execution.
-        void Panic(const std::string& p_panic_message) noexcept;
+        void Panic(const char* p_panic_message) noexcept;
     private:
         Logger m_logger;
 };

--- a/main.cpp
+++ b/main.cpp
@@ -61,10 +61,7 @@ long GetPortFromArgs(Util& util, int& argc, char** argv) noexcept
     const auto port = ArgParser::GetPortFromArg(argv[1]);
 
     if (port == 0 || port > USHRT_MAX) {
-        char* error_message = static_cast<char*>(malloc(sizeof(char) * 200));
-        error_message = strcpy(error_message, "The port argument was given an invalid value. Expected a port number within valid range; got: ");
-        error_message = strcat(error_message, argv[1]);
-        util.Panic(error_message);
+        util.Panic("The port argument was given an invalid value. Expected a port number within valid range; got: " + std::string(argv[1]) + "\n");
     }
 
     return port;

--- a/main.cpp
+++ b/main.cpp
@@ -61,7 +61,10 @@ long GetPortFromArgs(Util& util, int& argc, char** argv) noexcept
     const auto port = ArgParser::GetPortFromArg(argv[1]);
 
     if (port == 0 || port > USHRT_MAX) {
-        util.Panic("The port argument was given an invalid value. Expected a port number within valid range; got: " + std::string(argv[1]));
+        char* error_message = static_cast<char*>(malloc(sizeof(char) * 200));
+        error_message = strcpy(error_message, "The port argument was given an invalid value. Expected a port number within valid range; got: ");
+        error_message = strcat(error_message, argv[1]);
+        util.Panic(error_message);
     }
 
     return port;

--- a/unittests/logger_tests.cpp
+++ b/unittests/logger_tests.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <fstream>
 #include "../vendor/catch2.hpp"
 #include "../Logger/logger.hpp"
 #include "../PathHandler/path_handler.hpp"


### PR DESCRIPTION
- No Windows support as of now (might come back in future releases);
- Refactoring logs;
- More `constexpr`s;
- Using _C-style_ strings and fixing exception message logs;
- Fixing "invalid port" message where there would be no newline at the end of the string.